### PR TITLE
Add missing const to throttled variable definition

### DIFF
--- a/src/Waypoint.svelte
+++ b/src/Waypoint.svelte
@@ -111,7 +111,7 @@
 
     checkIsVisible();
 
-    throttled = throttleFn(checkIsVisible, throttle);
+    const throttled = throttleFn(checkIsVisible, throttle);
 
     window.addEventListener('scroll', throttled);
     window.addEventListener('resize', throttled);


### PR DESCRIPTION
I stumbled upon some errors in older safari versions. 
`Unhandled Promise Rejection: ReferenceError: Can't find variable: throttled`

Attached PR + [polyfill](https://github.com/w3c/IntersectionObserver/tree/master/polyfill) fixed it.